### PR TITLE
Fix python<3.5 compatibility for SecretStorage dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
       'boto3',
       'keyring',
       'dbus-python',
-      'secretstorage'
+      "secretstorage < 3 ; python_version < '3.5'",
+      "secretstorage; python_version >= '3.5'"
     ]
 )


### PR DESCRIPTION
According to SecretStorage documentation:
`SecretStorage 3.x supports Python 3.5 and newer versions. If you have an older version of Python, install SecretStorage 2.x`

Tested in virtualenv with python2.7 and python3.7