### PR TITLE
creates the .aws home directory if it doesn't exist

### DIFF
--- a/awsmfa/__init__.py
+++ b/awsmfa/__init__.py
@@ -19,7 +19,8 @@ from awsmfa.util import log_error_and_exit, prompter
 
 logger = logging.getLogger('aws-mfa')
 
-AWS_CREDS_PATH = '%s/.aws/credentials' % (os.path.expanduser('~'),)
+AWS_USER_PATH_DIR = f'{os.path.expanduser("~")}/.aws'
+AWS_CREDS_PATH = f'{AWS_USER_PATH_DIR}/credentials'
 
 
 def main():
@@ -99,6 +100,8 @@ def main():
                                "would you like to create one? "
                                "[y/n]".format(AWS_CREDS_PATH))
         if create.lower() == "y":
+            if not os.path.isdir(AWS_USER_PATH_DIR):
+                os.mkdir(AWS_USER_PATH_DIR)
             with open(AWS_CREDS_PATH, 'a'):
                 pass
         else:


### PR DESCRIPTION
I updated the initial setup so that it would create the $HOME/.aws directory as well as the credentials file if it doesn't exist to make initial setup a bit smoother. I can create tests for this if desired, but I didn't see any others so I passed for now. That said it worked fine locally - below you can see the output.

```
[morgana@Morgans-MacBook-Pro:~/src/aws-mfa]
>>>aws-mfa - master
$>rm -rf ~/.aws

[morgana@Morgans-MacBook-Pro:~/src/aws-mfa]
>>>aws-mfa - master
$>aws-mfa --setup
Could not locate credentials file at /Users/morgana/.aws/credentials, would you like to create one? [y/n]y
Profile name to [default]:
...

[morgana@Morgans-MacBook-Pro:~/src/aws-mfa]
>>>aws-mfa - create_home_aws_dir_if_not_exists
$>ls -al ~/.aws/credentials
-rw-r--r--  1 morgana  staff  0 Mar  8 11:27 /Users/morgana/.aws/credentials
```

Additionally, I used f-strings, but I'm not sure if we want to maintain python2 compatibility. Thoughts?